### PR TITLE
SUD-43 Add Sudoku.build_grid() and test

### DIFF
--- a/src/cell.py
+++ b/src/cell.py
@@ -17,7 +17,7 @@ class Cell:
             self.__alternatives: set[CellValue] = (set() if init_value is not None
                                                    else {1, 2, 3, 4, 5, 6, 7, 8, 9})
         else:
-            raise ValueError('Incorrect value')
+            raise ValueError('Incorrect value', init_value)
 
     def __eq__(self, other):
         return self.__value == other.__value

--- a/src/sudoku.py
+++ b/src/sudoku.py
@@ -136,7 +136,7 @@ class Sudoku:
         grids = [Sudoku()]
         i = 1
         while i < 10:
-            grids.append(Sudoku(grids[i-1].get_grid()))
+            grids.append(Sudoku(grids[i - 1].get_grid()))
             for row in grids[i].__rows:
                 cell_is_defined = False
                 cell_indexes = random.sample(range(9), 9)

--- a/src/sudoku.py
+++ b/src/sudoku.py
@@ -1,8 +1,10 @@
 from itertools import product
 from collections import Counter
+import random
 from typing import Sequence
 import copy
 import logging
+
 
 from cell import Cell, CellStateException
 from utils import is_valid_grid, draw_grid
@@ -20,7 +22,7 @@ class InvalidSudokuException(Exception):
 
 class Sudoku:
 
-    def __init__(self, grid: Grid) -> None:
+    def __init__(self, grid: Grid = [[None for i in range(9)] for j in range(9)]) -> None:
         if not is_valid_grid(grid):
             raise ValueError('Incorrect grid. Expected grid 9x9')
         self.__rows = [[Cell(item) for item in row] for row in grid]
@@ -128,3 +130,28 @@ class Sudoku:
                         self.__rows[i][j].exclude(sudoku_copy.__rows[i][j].value)
                         return True
         return False
+
+    @staticmethod
+    def build_grid():
+        grids = [Sudoku()]
+        i = 1
+        while i < 10:
+            grids.append(Sudoku(grids[i-1].get_grid()))
+            for row in grids[i].__rows:
+                cell_is_defined = False
+                cell_indexes = random.sample(range(9), 9)
+                for k in cell_indexes:
+                    if not row[k].is_solved:
+                        row[k]._Cell__value = i
+                        if grids[i].__is_valid():
+                            cell_is_defined = True
+                            break
+                        else:
+                            row[k]._Cell__value = None
+                if not cell_is_defined:
+                    grids.pop()
+                    grids.pop()
+                    i -= 2
+                    break
+            i += 1
+        return grids[9].get_grid()

--- a/tests/test_sudoku.py
+++ b/tests/test_sudoku.py
@@ -114,3 +114,9 @@ def test_LEA():
         grid_view[i][j]._Cell__alternatives == {1, 2, 3, 4, 5, 6, 7, 8, 9}
         for j in range(9) for i in range(1, 9)
     )
+
+
+def test_sudoku_build_grid():
+    sudoku = Sudoku(Sudoku.build_grid())
+    assert sudoku._Sudoku__is_valid()
+    assert sudoku.is_solved


### PR DESCRIPTION
Метод Sudoku.build_grid() реализован. Примечание:
1. Не понадобилось делать словарь для хранения попыток, процесс в случае необходимости сам откатывается назад на 1-3 позиции. Для построения итоговой сетки требуется от 1 до 360-350 попыток расставить значение в судоку. (1 раз даже все расставилось с одной попытки!)
2. Метод возвращает не объект Sudoku, а Grid = list[list[CellValue]]. Мне кажется так будет удобнее для дальнейшего его использования: генерации задания или для передачи на фронт.